### PR TITLE
V10 depreciation warnings fixed

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,4 +1,5 @@
 {
+  "id": "game-icons-net",
   "name": "game-icons-net",
   "title": "Game-icons.net",
   "description": "3800+ Icons from game-icons-net to use in your game. Browse to the Data/modules/game-icons-net/ directory for all your icon needs.",


### PR DESCRIPTION
Added "id" to module.json in order to stop foundry v10 complaining about depreciation problems.
This change should still work with foundry v9, as "name" is not deleted.